### PR TITLE
fix: remove pip upgrade step that fails on macOS arm64 runners

### DIFF
--- a/.github/workflows/wheelbuilder3.9.yml
+++ b/.github/workflows/wheelbuilder3.9.yml
@@ -36,10 +36,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install dependencies
-        run: |
-          python3 -m pip install --upgrade pip --break-system-packages
-
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.1.4
         env:


### PR DESCRIPTION
The 'python3 -m pip install --upgrade pip --break-system-packages' step fails on macos-latest (arm64/macos-15) because the system python3 is Homebrew's Python 3.14, whose pip lacks a RECORD file and cannot be uninstalled/upgraded.

This step is unnecessary since cibuildwheel manages its own isolated build environments with their own pip.